### PR TITLE
fix concluding requests if no matches

### DIFF
--- a/lua/telescope-hierarchy/lsp.lua
+++ b/lua/telescope-hierarchy/lsp.lua
@@ -102,9 +102,13 @@ function lsp.get_calls(position, each_cb, final_cb)
     if result == nil then
       return
     end
+    local results_counter = #result
+    if results_counter == 0 then
+      final_cb()
+    end
+
     local direction = assert(state.direction())
     local method = direction:is_incoming() and "callHierarchy/incomingCalls" or "callHierarchy/outgoingCalls"
-    local results_counter = #result
     for _, item in ipairs(result) do
       make_request(method, { item = item }, function(calls)
         each_cb(calls)


### PR DESCRIPTION
i noticed that the display would never update if there are no callers.

this happened to me in react with a render() function that noone "calls", since it's the react framework calling it, there are no callers for the LSP to find.