### PR TITLE
fix: expanding multiple layers

### DIFF
--- a/lua/telescope-hierarchy/actions.lua
+++ b/lua/telescope-hierarchy/actions.lua
@@ -34,42 +34,59 @@ end
 ---Recursively expand the current node
 ---Since this could be quite expensive, it takes a depth parameter
 ---and will only expand to that many layers deep
----@param node Node
----@param depth integer
----@param refresh_cb fun(node: Node)
+---@async
+---@param node Node The node from which to perform the recursive expansion
+---@param depth integer The depth to which to expand the current node
+---@param refresh_cb fun(node: Node) A callback to trigger a repaint of the picker window
 local function expand_all_to(node, depth, refresh_cb)
   ---Recursive heart of this function
-  ---@param level integer
-  ---@param frontier Node[]
-  local function process_level(level, frontier, cb)
+  ---@async
+  ---@param level integer A counter for which level (counting down towards 1) we are in
+  ---@param frontier Node[] A list of nodes that are to be processed at the current level
+  local function process_level(level, frontier)
     ---@type Node[]
     local next = {}
     local remaining = #frontier
 
+    ---Callback function to be run on the expanded node once the call to the LSP
+    ---has resolved
+    ---@async
+    ---@param expanded Node
+    ---@param pending boolean
+    local once_expanded = function(expanded, pending)
+      -- This allows us to repaint the picker window if the node is only in
+      -- a pending state
+      -- The early return will ensure that the remaining processing,
+      -- which is intended for the node once expanded, is skipped
+      if pending then
+        refresh_cb(expanded)
+        return
+      end
+
+      for _, child in ipairs(expanded.children) do
+        table.insert(next, child)
+      end
+
+      remaining = remaining - 1
+      if remaining == 0 then
+        if level > 1 and #next > 0 then
+          process_level(level - 1, next)
+        else
+          refresh_cb(node)
+        end
+      end
+    end
+
     for _, to_be_expanded in ipairs(frontier) do
-      to_be_expanded:expand(function(expanded, pending)
-        if pending then
-          cb(node)
-          return
-        end
-
-        for _, child in ipairs(expanded.children) do
-          table.insert(next, child)
-        end
-
-        remaining = remaining - 1
-        if remaining == 0 then
-          if level > 1 and #next > 0 then
-            process_level(level - 1, next, cb)
-          else
-            cb(node)
-          end
-        end
-      end, true)
+      -- Pass force_cb as true to ensure that even nodes that
+      -- are known to have no children or be recursive trigger the callback
+      -- This is necessary to ensure that the remaining counter above
+      -- counts down to zero correctly and we don't hang mid-processing
+      to_be_expanded:expand(once_expanded, true)
     end
   end
 
-  process_level(depth, { node }, refresh_cb)
+  process_level(depth, { node })
 end
 
 M.expand = function(prompt_bufnr)

--- a/lua/telescope-hierarchy/tree/node.lua
+++ b/lua/telescope-hierarchy/tree/node.lua
@@ -147,11 +147,10 @@ end
 ---@param callback fun(node: Node, pending: boolean | nil) Function to be run once children have been found (async) & the node expanded
 ---@param force_cb boolean | nil
 function Node:expand(callback, force_cb)
-  if self.expanded and force_cb then
-    callback(self)
-    return
-  end
   if self.expanded or self.recursive then
+    if force_cb then
+      callback(self)
+    end
     return
   end
 


### PR DESCRIPTION
When we have a recursive node it was not force returning to the expansion function, which meant that the processing was not counted as having taken place and the multi-expansion would hang at that layer. Now fixed so that recursive states can also be force_cb

While I was here, I spruced up some of the documentation on the gnarlier callback code within the `expand_all_to` function since the callback hell is especially strong here