### PR TITLE
feat: default Telescope action

### DIFF
--- a/lua/telescope/_extensions/hierarchy.lua
+++ b/lua/telescope/_extensions/hierarchy.lua
@@ -36,6 +36,10 @@ local function final_config(config)
   end
 end
 
+M.exports.hierarchy = function(config)
+  hierarchy.incoming_calls(final_config(config))
+end
+
 M.exports.incoming_calls = function(config)
   hierarchy.incoming_calls(final_config(config))
 end


### PR DESCRIPTION
Telescope users expect to be able to type `:Telescope hierarchy` and have the extension work. I didn't offer this before as which direction should be picked? To save the error, I pick a default direction of incoming so `:Telescope hierarchy` without further arguments and not generate an error