### PR TITLE
feat: initial multi-expand option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,31 @@ return {
     -- don't use `defaults = { }` here, do this in the main telescope spec
     extensions = {
       hierarchy = {
-        -- telescope-hierarchy.nvim config, see below
+        -- telescope-hierarchy.nvim config
+        -- these are the defaults and no need to reset them if you like these
+        initial_multi_expand = false, -- Run a multi-expand on open? If false, will only expand one layer deep by default
+        multi_depth = 5, -- How many layers deep should a multi-expand go?
+        mappings = {
+          i = {}, -- this plugin does not work in insert mode, as that would imply filtering the tree
+          n = {
+            ["e"] = actions.expand,
+            --["e"] = false, -- to reset the 'e' key, if you don't want it mapped
+            ["E"] = actions.multi_expand,
+            ["l"] = actions.expand,
+            ["<RIGHT>"] = actions.expand,
+
+            ["c"] = actions.collapse,
+            ["h"] = actions.collapse,
+            ["<LEFT>"] = actions.collapse,
+
+            ["t"] = actions.toggle,
+            ["s"] = actions.switch,
+            ["d"] = actions.goto_definition,
+
+            ["q"] = actions.quit,
+          },
+        },
+        layout_strategy = "horizontal",
       },
       -- no other extensions here, they can have their own spec too
     },

--- a/lua/telescope-hierarchy/defaults.lua
+++ b/lua/telescope-hierarchy/defaults.lua
@@ -3,11 +3,13 @@ local actions = require("telescope-hierarchy.actions")
 local M = {}
 
 M.opts = {
+  initial_multi_expand = false,
+  multi_depth = 5,
   mappings = {
     i = {},
     n = {
       ["e"] = actions.expand,
-      ["E"] = actions.expand_5,
+      ["E"] = actions.multi_expand,
       ["l"] = actions.expand,
       ["<RIGHT>"] = actions.expand,
 

--- a/lua/telescope-hierarchy/init.lua
+++ b/lua/telescope-hierarchy/init.lua
@@ -2,18 +2,31 @@ local tree = require("telescope-hierarchy.tree")
 local ui = require("telescope-hierarchy.ui")
 local direction = require("telescope-hierarchy.enums.direction")
 local mode = require("telescope-hierarchy.enums.mode")
+local state = require("telescope-hierarchy.state")
 
 local M = {}
 
 M.incoming_calls = function(opts)
   tree.new(mode.CALL, direction.INCOMING, function(root)
-    ui.show(root:to_list(false), opts)
+    local p = ui.show(root:to_list(false), opts)
+    if p and opts.initial_multi_expand then
+      local depth = state.get("multi_depth")
+      root:multi_expand(depth, function(expanded_tree)
+        ui.refresh(expanded_tree, p)
+      end)
+    end
   end)
 end
 
 M.outgoing_calls = function(opts)
   tree.new(mode.CALL, direction.OUTGOING, function(root)
-    ui.show(root:to_list(false), opts)
+    local p = ui.show(root:to_list(false), opts)
+    if p and opts.initial_multi_expand then
+      local depth = state.get("multi_depth")
+      root:multi_expand(depth, function(expanded_tree)
+        ui.refresh(expanded_tree, p)
+      end)
+    end
   end)
 end
 

--- a/lua/telescope/_extensions/hierarchy.lua
+++ b/lua/telescope/_extensions/hierarchy.lua
@@ -5,9 +5,13 @@ end
 
 local hierarchy = require("telescope-hierarchy")
 local defaults = require("telescope-hierarchy.defaults")
+local state = require("telescope-hierarchy.state")
 
 local function extend_config(base, extend)
   local config = vim.tbl_deep_extend("force", base, extend)
+
+  -- set multi expansion depth in the global state
+  state.set("multi_depth", config.multi_depth)
 
   -- remove default keymaps that have been disabled by the user
   for _, mode in ipairs({ "i", "n" }) do


### PR DESCRIPTION
User requested feature to allow the tree to initially open with a multi-expand. To get this to work sensibly I created options both for how deep a multi-expand goes and whether the initial open action will multi-expand, with the default being as before for a multi-expand depth of 5 and no multi-expand on open

I took the opportunity to move some of the code out of actions to Node and UI modules as it made more sense there