### PR TITLE
fix: display all occurences of function call

### DIFF
--- a/lua/telescope-hierarchy/tree/node.lua
+++ b/lua/telescope-hierarchy/tree/node.lua
@@ -117,8 +117,8 @@ function Node:search(callback)
     for _, range in ipairs(call.fromRanges) do
       -- Check for duplicate ranges from LSP
       -- Assumes the duplicates are sequential. Would need to do more work if they are unordered
-      if range.start.line ~= last_line and range.start.character ~= last_char then
-        self:new_child(uri, inner.name, range.start.line + 1, range.start.character, entry)
+      if range.start.line ~= last_line or range.start.character ~= last_char then
+        self:new_child(uri, inner.name, range.start.line + 1, range.start.character + 1, entry)
         last_line = range.start.line
         last_char = range.start.character
       end


### PR DESCRIPTION
In the scenario where a function is called several times with the same indentation, for instance:
```c
int main()
{
  do_somethin();
  do_somethin();
  do_somethin();
}
```

The language server (for instance clangd) would return something similar to:
```sh
...
 fromRanges = { {
      ["end"] = {
        character = 10,
        line = 266
      },
      start = {
        character = 2,
        line = 266
      }
    }, {
      ["end"] = {
        character = 10,
        line = 267
      },
      start = {
        character = 2,
        line = 267
      }
    }, {
      ["end"] = {
        character = 10,
        line = 315
      },
      start = {
        character = 2,
        line = 315
      }
    },
...
```

where the field ```character``` is always the same and as a result we were not showing all occurences of these functions